### PR TITLE
Registering quest and getting first node

### DIFF
--- a/qs-client/src/layouts/MainLayout.vue
+++ b/qs-client/src/layouts/MainLayout.vue
@@ -182,10 +182,19 @@ export default {
       this.rightDrawerOpen = false;
       document.getElementById("mySidenav").style.width = "0";
     },
+    goTo(route) {
+      this.rightDrawer = false;
+      this.leftDrawer = false;
+      this.$router.push({ name: route });
+    },
     logout() {
       this.rightDrawer = false;
       this.leftDrawer = false;
+      document.getElementById("mySidenav").style.width = "0";
       this.$store.dispatch("member/logout")
+      this.$store.dispatch("conversation/logout")
+      this.$store.dispatch("quests/logout")
+      this.$store.dispatch("guilds/logout")
       .then(response => {
           this.$q.notify({
             type: "positive",
@@ -193,11 +202,6 @@ export default {
           });
            this.goTo('home');
       })
-    },
-    goTo(route) {
-      this.rightDrawer = false;
-      this.leftDrawer = false;
-      this.$router.push({ name: route });
     },
   }
 };

--- a/qs-client/src/pages/Guilds.vue
+++ b/qs-client/src/pages/Guilds.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page style ="background-color:lightgrey" >
+  <q-page class = 'bg-grey-4'>
     <div class="column items-center">
       <div class="col-4 q-pa-lg" style="width: 1000px">
         <scoreboard></scoreboard>
@@ -32,8 +32,8 @@
 
 <script>
 
-import { mapGetters } from "vuex";
 import scoreboard from '../components/scoreboard.vue'
+import { mapGetters } from 'vuex'
 
 export default {
   props: ["member"],
@@ -87,12 +87,13 @@ export default {
     "scoreboard": scoreboard
   },
   computed: {
+    ...mapGetters('guilds', ['getGuilds']),
     guildList() {
-      return  this.$store.getters['guilds/getGuilds'];
+      return  this.getGuilds;
     }
   },
 
-  async beforeMount() {
+  async beforeCreate() {
      const guilds = await this.$store.dispatch('guilds/findGuilds');
      console.log('find guilds returns: ', guilds);
   }

--- a/qs-client/src/services/conversationService.js
+++ b/qs-client/src/services/conversationService.js
@@ -1,6 +1,6 @@
 import axiosInstance from "../boot/axios";
 
-export async function addConversation(payload, token) {
+export async function addConversationNode(payload, token) {
     const options = token ? {
       headers: {
         'Authorization': `Bearer ${token}`
@@ -14,7 +14,7 @@ export async function addConversation(payload, token) {
     }).catch(err => {
       if (err.response) {
         let errorCode = err.response.data.code;
-        console.log ("Error in adding conversation", err.response)
+        console.log ("Error in adding conversation node", err.response)
       }
     })
   }
@@ -33,5 +33,20 @@ export async function addConversation(payload, token) {
         let errorCode = err.response.data.code;
         console.log ("Error in adding conversation", err.response)
       }
+    })
+  }
+  export async function getParentNode(payload, token) {
+    const options = token ? {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    } : {};
+   return axiosInstance.get("/conversation_node?id=eq." + payload,
+   options
+    ).then (response => {
+      return response;
+    }).catch(err => {
+        let errorCode = err.response.data.code;
+        console.log ("Error in adding conversation", err.response)
     })
   }

--- a/qs-client/src/services/guildService.js
+++ b/qs-client/src/services/guildService.js
@@ -46,7 +46,7 @@ export async function getGuilds(opts, token) {
     if (err.response) {
       let errorCode = err.response.data.code;
         Notify.create({
-          message: `There was an error updating quest. If this issue persists, contact support.`,
+          message: `There was an error updating quild. If this issue persists, contact support.`,
           color: "negative"
         });
         console.log ("Error in updating guild ", err.response)
@@ -164,6 +164,20 @@ export async function getGuilds(opts, token) {
       }
     })
   }
+  export async function getGamePlayByGuildIdAndQuestId(payload, token) {
+    const options = token ? {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    } : {};
+    return axiosInstance.get("/game_play?guild_id=eq." + payload.guild_id + "&quest_id=eq." + payload.quest_id, options
+    ).then (response =>{
+      return response})
+      .catch (err => {
+        let errorCode = err.response.data.code;
+        console.log("Error in getting game_play", err);
+      })
+  }
 
   export async function getGamePlayByGuildId(guildId, token) {
     const options = token ? {
@@ -178,6 +192,24 @@ export async function getGuilds(opts, token) {
         let errorCode = err.response.data.code;
         console.log("Error in get member in guild with guildId " + id, err);
       })
+  }
+  export async function updateGamePlay(payload, token) {
+    const options = token ? {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    } : {};
+
+   return axiosInstance.patch(`/game_play?guild_id=eq.${payload.guild_id} &quest_id=eq.${payload.quest_id}`, payload, options
+   ).then (function(response) {
+      console.log("Game_play was updated successfully");
+      return response;
+   }).catch(err => {
+    if (err.response) {
+      let errorCode = err.response.data.code;
+        console.log ("Error in updating game_play ", err.response)
+      }
+    })
   }
 
   export async function getGuildMembersById(guild_id, token) {

--- a/qs-client/src/store/conversation/actions.js
+++ b/qs-client/src/store/conversation/actions.js
@@ -1,14 +1,14 @@
 import conversationService from "../../services";
 
-export async function addConversation ({commit, dispatch}, payload) {
+export async function addConversationNode ({commit, dispatch}, payload) {
     try {
         const token = this.state.member.token;
-        let response = await conversationService.addConversation(payload, token)
-        dispatch('getConversationByQuestId', payload.quest_id);
+        let response = await conversationService.addConversationNode(payload, token)
+        response = await dispatch('getConversationByQuestId', payload.quest_id);
         return response.data
     }
     catch (error) {
-        console.log("error in adding conversation", error)
+        console.log("error in adding conversation node", error)
     }
 }
 export async function getConversationByQuestId ({commit, dispatch}, payload) {
@@ -51,12 +51,32 @@ export async function createConversationTree({commit}) {
     tree.push(treeView);
     Promise.resolve(commit('CREATE_TREE', tree));
 }
+export async function logout ({commit}) {
+    this.state.conversation.conversation = null;
+    this.state.conversation.showTree = false;
+    this.state.conversation.conversationTree = null;
+    this.state.conversation.parentNode = null;
+    return true
+  }
 export function setConversationNode({commit, getters}, parent_id) {
-    const conversation = getters.getConversationNodeById(parent_id)
-    return Promise.resolve(commit('SET_PARENT_CONVERSATION' ,conversation))
+    const node = getters.getConversationNodeById(parent_id)
+    return Promise.resolve(commit('SET_PARENT_CONVERSATION' ,node))
 }
+export async function getParentNode({commit}, nodeId) {
+    try {
+        const token = this.state.member.token;
+        let response = await conversationService.getParentNode(nodeId, token)
+        return Promise.resolve(commit('SET_PARENT_NODE', response.data));
 
-
+        return response.data[0]
+    }
+    catch (error) {
+        console.log("error in getting parentNode", error)
+    }
+}
+export function setParentNode({commit}) {
+    return Promise.resolve(commit('SET_PARENT_NODE, opt.data[0]'));
+}
 export function setConversationData({commit}) {
-    return Promise.resolve(commit('SET_CONVERSATION_DATA, opt.data'))
+    return Promise.resolve(commit('SET_CONVERSATION_DATA, opt.data[0]'))
 }

--- a/qs-client/src/store/conversation/getters.js
+++ b/qs-client/src/store/conversation/getters.js
@@ -1,3 +1,5 @@
+import conversation from ".";
+import state from "../quest/state";
 
 export const getConversation = (state) => (stat) => {
 
@@ -8,4 +10,7 @@ export function getTreeView(state) {
 }
 export const getConversationNodeById = (state) => (id) => {
     return state.conversation.filter(conversation => conversation.id === id);
+}
+export const getFirstNode = (state) => (questId) => {
+    return state.conversation.filter(node => node.quest_id === questId && node.guild_id === null)
 }

--- a/qs-client/src/store/conversation/mutations.js
+++ b/qs-client/src/store/conversation/mutations.js
@@ -7,6 +7,6 @@ export function SHOW_TREE(state, show) {
 export function CREATE_TREE(state, tree) {
     state.conversationTree = tree;
 }
-export function SET_PARENT_CONVERSATION(state, parentConversation) {
-    state.parentConversation = parentConversation;
+export function SET_PARENT_NODE(state, parentNode) {
+    state.parentNode = parentNode;
 }

--- a/qs-client/src/store/conversation/state.js
+++ b/qs-client/src/store/conversation/state.js
@@ -1,8 +1,10 @@
 export default function () {
     return {
-      conversation: [],
+      conversation: [{
+        node: {}
+      }],
       showTree: false,
       conversationTree: null,
-      parentConversation: []
+      parentNode: null,
     }
   }

--- a/qs-client/src/store/guild/actions.js
+++ b/qs-client/src/store/guild/actions.js
@@ -121,6 +121,17 @@ export async function registerQuest({commit, state}, payload) {
 
         }
     }
+    export async function getGamePlayByGuildIdAndQuestId ({commit, dispatch}, payload) {
+        try {
+            const token = this.state.member.token;
+            let response = await guildService.getGamePlayByGuildIdAndQuestId(payload, token)
+            commit('SET_GAME_PLAY_DATA', response.data[0]);
+            return response.data
+        }
+        catch (error) {
+            console.log("error in get game play by guild id", error)
+        }
+    }
     export async function registerAllMembersToQuest({commit, dispatch}, params, token) {
         try {
             const token = this.state.member.token;
@@ -131,9 +142,27 @@ export async function registerQuest({commit, state}, payload) {
             console.log("Error in registering all members to quest: ", error)
         }
     }
+    export async function setFocusNodeId({commit}, payload) {
+        try {
+            const token = this.state.member.token;
+            let response = await guildService.updateGamePlay(payload, token)
+            return response.data
+        }
+        catch (error) {
+            console.log("error in get game play by guild id", error)
+        }
+
+    }
+    export async function logout ({commit}) {
+        this.state.guilds.guilds = null;
+        this.state.guilds.belongsTo = null;
+        this.state.guilds.currentGuild = null;
+        this.state.guilds.gamePlay = null;
+        return true
+      }
     export function setCurrentGuild({commit, getters}, guildId) {
-        let guild = getters.getGuildById(guildId)
-        return Promise.resolve(commit('SET_CURRENT_GUILD', guild[0]))
+        let guild = getters.getGuildById(guildId);
+        return Promise.resolve(commit('SET_CURRENT_GUILD', guild[0]));
     }
 
  export function setGuildData({commit}){

--- a/qs-client/src/store/guild/state.js
+++ b/qs-client/src/store/guild/state.js
@@ -1,7 +1,7 @@
 export default function () {
   return {
-    guilds: null,
-    belongsTo: null,
+    guilds: [{}],
+    belongsTo: [],
     currentGuild: null,
     gamePlay: null
   }

--- a/qs-client/src/store/quest/actions.js
+++ b/qs-client/src/store/quest/actions.js
@@ -50,6 +50,11 @@ export async function getQuestById( {commit}, questId) {
         console.log("get quest by id error: ", error);
     }
 }
+export async function logout ({commit}) {
+    this.state.quests.currentQuest = null;
+    this.state.quests.quests = null;
+    return true
+  }
 
 export function setCurrentQuest({commit, getters}, questId) {
     let quest = getters.getQuestById(questId)

--- a/qs-client/src/store/quest/state.js
+++ b/qs-client/src/store/quest/state.js
@@ -1,6 +1,6 @@
 export default function () {
   return {
-    quests: null,
+    quests: [{ }],
     currentQuest: null
   }
 }


### PR DESCRIPTION
This feature has already been rebased with dev. Added clearing state upon log out. Change to be using node instead of conversation. Added things like guild cannot register to a quest that is in draft. The focus node gets added after registration. And gets displayed in guild-app. Continued working on refactoring and UX design. Much, much work left to do. But can register users. Can not add there permissions yet. Create a quest and first node of conversation. Guild admin can register the quest if not in drat status. If more then one quest is register guild can choose which quest.